### PR TITLE
Replace try? with proper error handling and logging

### DIFF
--- a/Sources/NDKSwiftCashu/CashuCacheHelper.swift
+++ b/Sources/NDKSwiftCashu/CashuCacheHelper.swift
@@ -20,19 +20,31 @@ public struct CashuCacheHelper: Sendable {
     }
 
     public func getMintInfo(url: String) async -> NDKMintInfo? {
-        guard let data = await cache.getValue(forKey: "mint:\(url)", namespace: namespace),
-              let wrapper = try? JSONDecoder().decode(MintInfoWrapper.self, from: data) else {
+        guard let data = await cache.getValue(forKey: "mint:\(url)", namespace: namespace) else {
             return nil
         }
-        return wrapper.info
+
+        do {
+            let wrapper = try JSONDecoder().decode(MintInfoWrapper.self, from: data)
+            return wrapper.info
+        } catch {
+            NDKLogger.log(.warning, category: .wallet, "Failed to decode mint info for \(url): \(error.localizedDescription)")
+            return nil
+        }
     }
 
     public func isMintInfoStale(url: String, maxAge: TimeInterval) async -> Bool {
-        guard let data = await cache.getValue(forKey: "mint:\(url)", namespace: namespace),
-              let wrapper = try? JSONDecoder().decode(MintInfoWrapper.self, from: data) else {
+        guard let data = await cache.getValue(forKey: "mint:\(url)", namespace: namespace) else {
             return true
         }
-        return Date().timeIntervalSince(wrapper.timestamp) > maxAge
+
+        do {
+            let wrapper = try JSONDecoder().decode(MintInfoWrapper.self, from: data)
+            return Date().timeIntervalSince(wrapper.timestamp) > maxAge
+        } catch {
+            NDKLogger.log(.warning, category: .wallet, "Failed to decode mint info for staleness check \(url): \(error.localizedDescription)")
+            return true
+        }
     }
 
     public func invalidateMintCache(url: String) async throws {
@@ -64,10 +76,15 @@ public struct CashuCacheHelper: Sendable {
     public func getKeyset(id: String) async -> CashuSwift.Keyset? {
         // Need to search all keysets since we don't know the mintUrl
         let allKeysets = await cache.getValues(namespace: namespace, keyPrefix: "keyset:")
-        for (_, data) in allKeysets {
-            if let wrapper = try? JSONDecoder().decode(KeysetWrapper.self, from: data),
-               wrapper.keyset.keysetID == id {
-                return wrapper.keyset
+        for (key, data) in allKeysets {
+            do {
+                let wrapper = try JSONDecoder().decode(KeysetWrapper.self, from: data)
+                if wrapper.keyset.keysetID == id {
+                    return wrapper.keyset
+                }
+            } catch {
+                NDKLogger.log(.warning, category: .wallet, "Failed to decode keyset \(key): \(error.localizedDescription)")
+                continue
             }
         }
         return nil
@@ -75,8 +92,14 @@ public struct CashuCacheHelper: Sendable {
 
     public func getKeysets(mintUrl: String) async -> [CashuSwift.Keyset] {
         let keysets = await cache.getValues(namespace: namespace, keyPrefix: "keyset:\(mintUrl):")
-        return keysets.values.compactMap { data in
-            try? JSONDecoder().decode(KeysetWrapper.self, from: data).keyset
+        return keysets.compactMap { (key, data) in
+            do {
+                let wrapper = try JSONDecoder().decode(KeysetWrapper.self, from: data)
+                return wrapper.keyset
+            } catch {
+                NDKLogger.log(.warning, category: .wallet, "Failed to decode keyset \(key): \(error.localizedDescription)")
+                return nil
+            }
         }
     }
 
@@ -90,11 +113,15 @@ public struct CashuCacheHelper: Sendable {
         guard !keysets.isEmpty else { return true }
 
         var oldestTimestamp: Date?
-        for (_, data) in keysets {
-            if let wrapper = try? JSONDecoder().decode(KeysetWrapper.self, from: data) {
+        for (key, data) in keysets {
+            do {
+                let wrapper = try JSONDecoder().decode(KeysetWrapper.self, from: data)
                 if oldestTimestamp == nil || wrapper.timestamp < oldestTimestamp! {
                     oldestTimestamp = wrapper.timestamp
                 }
+            } catch {
+                NDKLogger.log(.warning, category: .wallet, "Failed to decode keyset \(key) for staleness check: \(error.localizedDescription)")
+                continue
             }
         }
 

--- a/Sources/NDKSwiftCore/Core/Utilities/ContentParser.swift
+++ b/Sources/NDKSwiftCore/Core/Utilities/ContentParser.swift
@@ -78,7 +78,13 @@ public enum ContentParser {
                     if let index = Int(indexString) {
                         // Check if it's a user mention
                         if let pubkey = mentionMap[index] {
-                            let npub = (try? String.toNpub(pubkey)) ?? pubkey
+                            let npub: String
+                            do {
+                                npub = try String.toNpub(pubkey)
+                            } catch {
+                                NDKLogger.log(.warning, category: .event, "Failed to convert pubkey to npub in #[index] mention: \(error)")
+                                npub = pubkey
+                            }
                             entities.append(.userMention(pubkey: pubkey, npub: npub))
                             components.append(.userMention(pubkey: pubkey, npub: npub))
                             replacements.append((range: range, replacement: "@\(npub)"))
@@ -170,8 +176,14 @@ public enum ContentParser {
                 if bech32.hasPrefix(NostrConstants.npubPrefix) {
                     entities.append(.npub(bech32))
                     components.append(.npubMention(bech32))
-                    if let pubkey = try? String.fromNpub(bech32) {
+                    do {
+                        guard let pubkey = try String.fromNpub(bech32) else {
+                            NDKLogger.log(.warning, category: .event, "Failed to decode npub: nil result")
+                            continue
+                        }
                         components.append(.userMention(pubkey: pubkey, npub: bech32))
+                    } catch {
+                        NDKLogger.log(.warning, category: .event, "Failed to decode npub: \(error)")
                     }
                 } else if bech32.hasPrefix(NostrConstants.nprofilePrefix) {
                     entities.append(.nprofile(bech32))
@@ -179,8 +191,11 @@ public enum ContentParser {
                 } else if bech32.hasPrefix(NostrConstants.notePrefix) {
                     entities.append(.note(bech32))
                     components.append(.noteMention(bech32))
-                    if let eventId = try? Bech32.eventId(from: bech32) {
+                    do {
+                        let eventId = try Bech32.eventId(from: bech32)
                         components.append(.eventMention(eventId))
+                    } catch {
+                        NDKLogger.log(.warning, category: .event, "Failed to decode note: \(error)")
                     }
                 } else if bech32.hasPrefix(NostrConstants.neventPrefix) {
                     entities.append(.nevent(bech32))
@@ -238,10 +253,16 @@ public enum ContentParser {
                 case .userMention(let pubkey, _):
                     return pubkey == user.pubkey
                 case .npub(let npub):
-                    if let pubkey = try? String.fromNpub(npub) {
+                    do {
+                        guard let pubkey = try String.fromNpub(npub) else {
+                            NDKLogger.log(.warning, category: .event, "Failed to decode npub for current user check: nil result")
+                            return false
+                        }
                         return pubkey == user.pubkey
+                    } catch {
+                        NDKLogger.log(.warning, category: .event, "Failed to decode npub for current user check: \(error)")
+                        return false
                     }
-                    return false
                 default:
                     return false
                 }

--- a/Sources/NDKSwiftCore/Models/Kinds/NDKNIP89Events.swift
+++ b/Sources/NDKSwiftCore/Models/Kinds/NDKNIP89Events.swift
@@ -124,7 +124,22 @@ extension NDKEvent {
         // Parse metadata from content if present
         let metadata: NIP89HandlerMetadata?
         if !content.isEmpty {
-            metadata = try? JSONCoding.decode(NIP89HandlerMetadata.self, from: content.data(using: .utf8) ?? Data())
+            do {
+                guard let data = content.data(using: .utf8) else {
+                    NDKLogger.log(.warning, category: .event, "Failed to convert NIP-89 handler content to UTF-8")
+                    metadata = nil
+                    return NIP89HandlerInfo(
+                        supportedKinds: supportedKinds,
+                        handlerURLs: handlerURLs,
+                        metadata: metadata,
+                        identifier: identifier
+                    )
+                }
+                metadata = try JSONCoding.decode(NIP89HandlerMetadata.self, from: data)
+            } catch {
+                NDKLogger.log(.warning, category: .event, "Failed to parse NIP-89 handler metadata: \(error)")
+                metadata = nil
+            }
         } else {
             metadata = nil
         }
@@ -230,6 +245,11 @@ extension NDKEventBuilder {
 extension NIP89HandlerMetadata {
     /// Convert to JSON string
     func toJSON() -> String {
-        return (try? JSONCoding.encodeToString(self)) ?? ""
+        do {
+            return try JSONCoding.encodeToString(self)
+        } catch {
+            NDKLogger.log(.warning, category: .event, "Failed to encode NIP-89 handler metadata to JSON: \(error)")
+            return ""
+        }
     }
 }

--- a/Sources/NDKSwiftCore/Models/NDKEvent.swift
+++ b/Sources/NDKSwiftCore/Models/NDKEvent.swift
@@ -232,11 +232,30 @@ public struct NDKEvent: Codable, Equatable, Hashable, Sendable {
     /// - Returns: true if the signature is valid, false otherwise
     public func verifySignature() -> Bool {
         // Calculate ID (needed for the comparison)
-        guard (try? calculateID()) == id else { return false }
+        do {
+            let calculatedID = try calculateID()
+            guard calculatedID == id else {
+                NDKLogger.log(.warning, category: .event, "Event ID mismatch during signature verification")
+                return false
+            }
+        } catch {
+            NDKLogger.log(.warning, category: .event, "Failed to calculate event ID for signature verification: \(error)")
+            return false
+        }
+
         // Convert hex string to Data
-        guard let messageData = id.hexDecoded() else { return false }
-        // Directly call Crypto.verify and handle its throwing nature
-        return (try? Crypto.verify(signature: sig, message: messageData, pubkey: pubkey)) ?? false
+        guard let messageData = id.hexDecoded() else {
+            NDKLogger.log(.warning, category: .event, "Failed to decode event ID hex for signature verification")
+            return false
+        }
+
+        // Verify signature
+        do {
+            return try Crypto.verify(signature: sig, message: messageData, pubkey: pubkey)
+        } catch {
+            NDKLogger.log(.warning, category: .event, "Signature verification failed: \(error)")
+            return false
+        }
     }
 
 

--- a/Sources/NDKSwiftCore/Models/NDKEventBuilder.swift
+++ b/Sources/NDKSwiftCore/Models/NDKEventBuilder.swift
@@ -517,8 +517,15 @@ public final class NDKEventBuilder {
             // Determine the type by prefix
             if bech32String.hasPrefix(NostrConstants.npubPrefix) {
                 // Decode npub to get public key
-                if let pubkey = try? PublicKey.fromNpub(bech32String) {
+                do {
+                    guard let pubkey = try PublicKey.fromNpub(bech32String) else {
+                        NDKLogger.log(.warning, category: .event, "Failed to decode npub in tagBech32: nil result")
+                        return self
+                    }
                     return await self.tagUser(pubkey)
+                } catch {
+                    NDKLogger.log(.warning, category: .event, "Failed to decode npub in tagBech32: \(error)")
+                    return self
                 }
 
             } else if bech32String.hasPrefix(NostrConstants.notePrefix) {

--- a/Sources/NDKSwiftCore/Models/NDKRelay.swift
+++ b/Sources/NDKSwiftCore/Models/NDKRelay.swift
@@ -592,7 +592,11 @@ public final class NDKRelay: RelayProtocol, Hashable, Equatable, Identifiable, @
         let reconnectTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(actualDelay * Double(TimeConstants.nanosecondsPerSecond)))
             guard let self = self, !Task.isCancelled else { return }
-            try? await self.connect()
+            do {
+                try await self.connect()
+            } catch {
+                NDKLogger.log(.warning, category: .relay, "Reconnection attempt failed for \(self.url): \(error)")
+            }
         }
 
         await stateActor.scheduleReconnectTask(reconnectTask)

--- a/Sources/NDKSwiftCore/Outbox/NDKPublishingStrategy.swift
+++ b/Sources/NDKSwiftCore/Outbox/NDKPublishingStrategy.swift
@@ -281,7 +281,11 @@ actor NDKPublishingStrategy {
         // Try to connect
         let relay = await ndk.pool.addRelay(normalizedUrl)
         relay.ndk = ndk
-        try? await relay.connect()
+        do {
+            try await relay.connect()
+        } catch {
+            NDKLogger.log(.warning, category: .outbox, "Failed to connect to relay \(normalizedUrl): \(error)")
+        }
         return relay
     }
 

--- a/Sources/NDKSwiftCore/Relay/NDKRelayConnection.swift
+++ b/Sources/NDKSwiftCore/Relay/NDKRelayConnection.swift
@@ -335,8 +335,13 @@ public actor NDKRelayConnection {
         }
 
         // Log network traffic
-        let parsed = try? NostrMessage.parse(from: json)
-        NDKNetworkLogger.logNetworkSend(to: url, message: json, parsed: parsed)
+        do {
+            let parsed = try NostrMessage.parse(from: json)
+            NDKNetworkLogger.logNetworkSend(to: url, message: json, parsed: parsed)
+        } catch {
+            NDKLogger.log(.warning, category: .network, "Failed to parse outgoing message for logging: \(error)")
+            NDKNetworkLogger.logNetworkSend(to: url, message: json, parsed: nil)
+        }
 
         #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS)
             guard let task = webSocketTask else {


### PR DESCRIPTION
## Summary
- Replace silent error suppression (`try?`) with explicit do-catch blocks and NDKLogger calls in priority areas
- Relay connections: Log connection and reconnection failures
- Cache operations: Log JSON decoding errors for mint info/keysets  
- Event parsing: Log signature verification and serialization errors
- Content parsing: Log pubkey/note decoding failures
- Keep `try?` only for Task.sleep and hardcoded regex patterns where failure is truly ignorable

## Files Modified
- NDKRelayConnection.swift - Log message parsing failures
- NDKPublishingStrategy.swift - Log relay connection failures
- NDKRelay.swift - Log reconnection failures
- CashuCacheHelper.swift - Log JSON decoding errors
- ContentParser.swift - Log pubkey/note parsing errors
- NDKEvent.swift - Log verification errors
- NDKEventBuilder.swift - Log npub decoding errors
- NDKNIP89Events.swift - Log metadata encoding/decoding errors

## Test plan
- [x] Build compiles successfully

Closes #9