### PR TITLE
Fix MemoryCache.saveEvent() to notify observers

### DIFF
--- a/Sources/NDKSwiftCore/Cache/MemoryCache.swift
+++ b/Sources/NDKSwiftCore/Cache/MemoryCache.swift
@@ -88,6 +88,9 @@ public actor MemoryCache: NDKCache {
         }
 
         events[event.id] = event
+
+        // Notify observers about the saved event
+        notifyEventObservers(for: event)
     }
 
     public func getEvent(id: String) async -> NDKEvent? {
@@ -382,11 +385,8 @@ public actor MemoryCache: NDKCache {
             await processDeletionEvent(event)
         }
 
-        // Save the event
+        // Save the event (this will also notify observers)
         try await saveEvent(event)
-        
-        // Notify observers about the new event
-        notifyEventObservers(for: event)
     }
 
     /// Process a kind:5 deletion event according to NIP-09


### PR DESCRIPTION
## Summary
- Fixed MemoryCache.saveEvent() to properly notify observers when events are saved
- Removed redundant notifyEventObservers() call from processEvent()

## Problem
The `MemoryCache.saveEvent()` method saved events to the cache but did not notify observers, breaking the observation contract. Only `processEvent()` called `notifyEventObservers()`, causing subscriptions using `observeEvents()` to miss events saved directly via `saveEvent()`.

## Solution
- Added `notifyEventObservers(for: event)` call in `saveEvent()` after storing the event
- Removed the redundant call from `processEvent()` since it's now handled by `saveEvent()`

## Impact
- Events saved via `saveEvent()` now properly trigger observer notifications
- Creates consistent behavior between `MemoryCache` and `SQLiteCache`
- Fixes the observation contract as documented in the critical-bugs-found.md

## Test plan
- [x] Ran existing test suite
- [x] Verified no new test failures introduced by this change
- [x] Pre-existing test failure in `testNetworkOnlyPolicy` is unrelated to this fix

Fixes #8