### PR TITLE
feat: NIP-46 local signer discovery + Observable connect model

### DIFF
--- a/Sources/NDKSwiftCore/Signers/NDKBunkerSigner.swift
+++ b/Sources/NDKSwiftCore/Signers/NDKBunkerSigner.swift
@@ -173,12 +173,25 @@ public actor NDKBunkerSigner: NDKSigner {
         public let url: String?
         public let image: String?
         public let perms: String?
+        /// Additional, non-standard query items appended verbatim to the nostrconnect:// URI.
+        ///
+        /// NIP-46 only standardizes `relay`, `secret`, `perms`, `name`, `url`, `image`. Use this
+        /// escape hatch for vendor extensions — e.g. iOS `callback=myapp://nip46` (read by
+        /// Primal-iOS and Nostrify) or per-signer `includeNWC` flags.
+        public let extraQueryItems: [URLQueryItem]?
 
-        public init(name: String? = nil, url: String? = nil, image: String? = nil, perms: String? = nil) {
+        public init(
+            name: String? = nil,
+            url: String? = nil,
+            image: String? = nil,
+            perms: String? = nil,
+            extraQueryItems: [URLQueryItem]? = nil
+        ) {
             self.name = name
             self.url = url
             self.image = image
             self.perms = perms
+            self.extraQueryItems = extraQueryItems
         }
     }
 
@@ -243,35 +256,26 @@ public actor NDKBunkerSigner: NDKSigner {
     }
 
     private func generateNostrConnectUri(pubkey: String, relays: [String], options: NostrConnectOptions?) -> String {
-        var uri = "nostrconnect://\(pubkey)"
-        var params: [String] = []
+        var items: [URLQueryItem] = []
 
-        if let name = options?.name {
-            params.append("name=\(name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
-        }
-        if let url = options?.url {
-            params.append("url=\(url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
-        }
-        if let image = options?.image {
-            params.append("image=\(image.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
-        }
-        if let perms = options?.perms {
-            params.append("perms=\(perms.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
-        }
-        if let secret = nostrConnectSecret {
-            params.append("secret=\(secret.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
-        }
-
-        // Add all relays (NIP-46 supports multiple relay URLs)
+        if let name = options?.name { items.append(URLQueryItem(name: "name", value: name)) }
+        if let url = options?.url { items.append(URLQueryItem(name: "url", value: url)) }
+        if let image = options?.image { items.append(URLQueryItem(name: "image", value: image)) }
+        if let perms = options?.perms { items.append(URLQueryItem(name: "perms", value: perms)) }
+        if let secret = nostrConnectSecret { items.append(URLQueryItem(name: "secret", value: secret)) }
         for relay in relays {
-            params.append("relay=\(relay.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")")
+            items.append(URLQueryItem(name: "relay", value: relay))
+        }
+        if let extras = options?.extraQueryItems {
+            items.append(contentsOf: extras)
         }
 
-        if !params.isEmpty {
-            uri += "?" + params.joined(separator: "&")
-        }
+        var components = URLComponents()
+        components.scheme = "nostrconnect"
+        components.host = pubkey
+        components.queryItems = items.isEmpty ? nil : items
 
-        return uri
+        return components.url?.absoluteString ?? "nostrconnect://\(pubkey)"
     }
 
     private func generateNostrConnectSecret() -> String {

--- a/Sources/NDKSwiftUI/Auth/NDKBunkerConnectModel.swift
+++ b/Sources/NDKSwiftUI/Auth/NDKBunkerConnectModel.swift
@@ -1,0 +1,240 @@
+import Combine
+import Foundation
+import NDKSwiftCore
+import OSLog
+import SwiftUI
+
+/// SwiftUI-friendly orchestrator for the `nostrconnect://` (NIP-46) login flow.
+///
+/// This is a thin `@Observable` wrapper over ``NDKBunkerSigner/nostrConnect(ndk:relays:localSigner:options:)``.
+/// Non-UI callers should prefer that async API directly; ``NDKBunkerConnectModel`` exists to bind
+/// the connect lifecycle to SwiftUI state.
+///
+/// ## Lifecycle
+///
+/// 1. Construct the model with relays, app metadata, and (optionally) an iOS callback URL.
+/// 2. Call `await model.start()` — typically from `.task { }`. This generates the
+///    `nostrconnect://` URI, probes for installed signer apps, and begins listening on relays.
+/// 3. Bind UI to `state`, `nostrConnectURI`, and `detectedSigner`.
+/// 4. When the user taps the hero button, call `model.handoff(openURL: openURL)`.
+/// 5. Observe `state == .connected(signer)` to retrieve the connected ``NDKBunkerSigner``.
+///
+/// ## iOS callback convention
+///
+/// `callback` is **not** standardized in NIP-46. It is, however, the de-facto convention adopted
+/// by Primal-iOS and Nostrify: the signer reads `callback=<url>` from the `nostrconnect://` URI
+/// and calls `UIApplication.shared.open(<url>)` after signing the connect request. That brings
+/// the host app back to the foreground; the actual handshake completes over relays.
+///
+/// Pass `callbackURL: URL(string: "myapp://nip46")` to enable this. The host app must register
+/// the scheme in its `Info.plist > CFBundleURLTypes`.
+@MainActor
+@Observable
+public final class NDKBunkerConnectModel {
+    /// Connect-flow state. The enum is intentionally narrow: `state == .connected(signer)` is the
+    /// terminal success signal; everything else is intermediate or failure.
+    public enum State: @unchecked Sendable {
+        /// Not started.
+        case idle
+        /// Generating the `nostrconnect://` URI and starting the relay subscription.
+        case generating
+        /// URI generated, relay subscription live, awaiting the remote signer's `connect` response.
+        case waitingForApproval
+        /// The remote signer asked the user to authenticate at a URL (NIP-46 `auth_url`,
+        /// used by nsec.app). The host should open this URL and continue listening — the
+        /// connect flow resumes on its own once the user authenticates.
+        case awaitingAuthChallenge(URL)
+        /// The bunker acknowledged the connect request. Use this signer for subsequent operations.
+        case connected(NDKBunkerSigner)
+        /// Terminal failure. Inspect the associated error for the reason.
+        case failed(any Error)
+    }
+
+    /// Errors raised by the model itself (the underlying signer may surface its own).
+    public enum ConnectError: LocalizedError {
+        case timeout
+        case pubkeyMismatch(expected: String, actual: String)
+        case alreadyStarted
+        case missingURI
+
+        public var errorDescription: String? {
+            switch self {
+            case .timeout:
+                return "The signer did not respond in time."
+            case let .pubkeyMismatch(expected, actual):
+                return "The signer returned a different account (expected \(expected.prefix(8))…, got \(actual.prefix(8))…)."
+            case .alreadyStarted:
+                return "Connect flow is already in progress."
+            case .missingURI:
+                return "Failed to generate the nostrconnect:// URI."
+            }
+        }
+    }
+
+    public private(set) var state: State = .idle
+    /// The generated `nostrconnect://` URI — non-nil from `.waitingForApproval` onwards.
+    /// Render it as a QR code or hand it to ``handoff(openURL:)``.
+    public private(set) var nostrConnectURI: String?
+    /// The first installed signer found in the configured registry, if any. `nil` when no known
+    /// signer is detected (the user can still scan/paste).
+    public private(set) var detectedSigner: NDKKnownSigner?
+
+    private let ndk: NDK
+    private let relays: [String]
+    private let options: NDKBunkerSigner.NostrConnectOptions
+    private let knownSigners: [NDKKnownSigner]
+    private let expectedPubkey: PublicKey?
+    private let approvalTimeout: Duration
+    private let logger = Logger(subsystem: "NDKSwiftUI", category: "BunkerConnect")
+
+    private var bunkerSigner: NDKBunkerSigner?
+    private var connectTask: Task<Void, Never>?
+    private var authUrlCancellable: AnyCancellable?
+
+    /// - Parameters:
+    ///   - ndk: The configured NDK instance.
+    ///   - relays: Relays the host listens on for the bunker's response. Typically a single
+    ///     well-known relay like `wss://relay.nsec.app` or `wss://relay.primal.net`.
+    ///   - options: NIP-46 metadata (name/url/image/perms) the bunker shows to the user.
+    ///   - callbackURL: Optional `myapp://<path>` URL the signer will open after signing.
+    ///     De-facto iOS convention — see the type-level discussion.
+    ///   - knownSigners: Registry to probe for installed signer apps. Defaults to ``NDKKnownSigner/allKnown``.
+    ///   - expectedPubkey: When non-nil (reconnect flow), the bunker's returned pubkey must
+    ///     match this or the model lands in `.failed(.pubkeyMismatch)` without exposing a signer.
+    ///   - approvalTimeout: How long to wait for the bunker's response before failing with
+    ///     `.timeout`. Defaults to 120 seconds.
+    public init(
+        ndk: NDK,
+        relays: [String],
+        options: NDKBunkerSigner.NostrConnectOptions = .init(),
+        callbackURL: URL? = nil,
+        knownSigners: [NDKKnownSigner] = NDKKnownSigner.allKnown,
+        expectedPubkey: PublicKey? = nil,
+        approvalTimeout: Duration = .seconds(120)
+    ) {
+        self.ndk = ndk
+        self.relays = relays
+        self.knownSigners = knownSigners
+        self.expectedPubkey = expectedPubkey
+        self.approvalTimeout = approvalTimeout
+
+        if let callbackURL {
+            var extras = options.extraQueryItems ?? []
+            extras.append(URLQueryItem(name: "callback", value: callbackURL.absoluteString))
+            self.options = NDKBunkerSigner.NostrConnectOptions(
+                name: options.name,
+                url: options.url,
+                image: options.image,
+                perms: options.perms,
+                extraQueryItems: extras
+            )
+        } else {
+            self.options = options
+        }
+    }
+
+    /// Generates the URI, probes for an installed signer, and begins listening for the bunker.
+    /// Idempotent only in the sense that a second call from non-idle state fails with `.alreadyStarted`.
+    public func start() async {
+        guard case .idle = state else {
+            state = .failed(ConnectError.alreadyStarted)
+            return
+        }
+        state = .generating
+        detectedSigner = NDKLocalSigner.detect(from: knownSigners)
+
+        do {
+            let signer = try await NDKBunkerSigner.nostrConnect(
+                ndk: ndk,
+                relays: relays,
+                options: options
+            )
+            bunkerSigner = signer
+
+            var uri: String?
+            for _ in 0 ..< 20 {
+                uri = await signer.nostrConnectUri
+                if uri != nil { break }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+            guard let uri else {
+                state = .failed(ConnectError.missingURI)
+                return
+            }
+            nostrConnectURI = uri
+
+            let publisher = await signer.authUrlPublisher
+            authUrlCancellable = publisher.sink { [weak self] urlString in
+                guard let url = URL(string: urlString) else { return }
+                Task { @MainActor [weak self] in
+                    self?.state = .awaitingAuthChallenge(url)
+                }
+            }
+
+            state = .waitingForApproval
+            connectTask = Task { [weak self] in
+                await self?.runConnect(signer: signer)
+            }
+        } catch {
+            state = .failed(error)
+        }
+    }
+
+    private func runConnect(signer: NDKBunkerSigner) async {
+        let timeout = approvalTimeout
+        do {
+            let connectedPubkey: PublicKey = try await withThrowingTaskGroup(of: PublicKey.self) { group in
+                group.addTask { try await signer.connect() }
+                group.addTask {
+                    try await Task.sleep(for: timeout)
+                    throw ConnectError.timeout
+                }
+                let first = try await group.next()
+                group.cancelAll()
+                return first ?? ""
+            }
+
+            if let expected = expectedPubkey, connectedPubkey != expected {
+                state = .failed(ConnectError.pubkeyMismatch(expected: expected, actual: connectedPubkey))
+                return
+            }
+            state = .connected(signer)
+        } catch {
+            // If the timeout fires first the group may emit either the timeout or a cancellation
+            // error; both should land as `.failed` if we're not already in a terminal state.
+            if case .connected = state { return }
+            state = .failed(error)
+        }
+    }
+
+    /// Opens the generated `nostrconnect://` URI via the SwiftUI `OpenURLAction`.
+    ///
+    /// iOS routes the URI to whichever app registered the `nostrconnect` scheme (typically the
+    /// installed signer). No-op if `start()` hasn't completed yet.
+    ///
+    /// Pass `using` from a SwiftUI view:
+    /// ```swift
+    /// @Environment(\.openURL) private var openURL
+    /// // ...
+    /// Button("Open signer") { model.handoff(using: openURL) }
+    /// ```
+    public func handoff(using openURL: OpenURLAction) {
+        guard let uri = nostrConnectURI, let url = URL(string: uri) else { return }
+        openURL(url)
+    }
+
+    /// Cancels the in-flight connect and resets the model to `.idle`. Safe to call multiple times.
+    public func cancel() {
+        connectTask?.cancel()
+        connectTask = nil
+        authUrlCancellable?.cancel()
+        authUrlCancellable = nil
+        let signer = bunkerSigner
+        bunkerSigner = nil
+        nostrConnectURI = nil
+        state = .idle
+        if let signer {
+            Task { await signer.disconnect() }
+        }
+    }
+}

--- a/Sources/NDKSwiftUI/Auth/NDKKnownSigner.swift
+++ b/Sources/NDKSwiftUI/Auth/NDKKnownSigner.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A known iOS NIP-46 signer app that can be probed via custom URL scheme and handed off to.
+///
+/// This is presentation metadata for the "is signer X installed → tap to hand off" UX. It is *not*
+/// a security boundary: any app on the device can claim a URL scheme. Treat the registry as a
+/// convenience shortcut for users who have an installed signer; the bunker:// / nostrconnect://
+/// QR-and-paste flows remain the source of truth.
+///
+/// To detect installed signers at runtime, the host app **must** list each `urlScheme` under
+/// `LSApplicationQueriesSchemes` in its Info.plist. Otherwise `UIApplication.canOpenURL` returns
+/// `false` even when the signer is installed. See ``NDKLocalSigner``.
+public struct NDKKnownSigner: Sendable, Hashable, Identifiable {
+    /// Stable identifier (e.g. `"amber"`, `"primal"`, `"nsec.app"`).
+    public let id: String
+
+    /// Human-readable name shown in UI.
+    public let displayName: String
+
+    /// Custom URL scheme registered by the signer app, without `://`. Used by both
+    /// `UIApplication.canOpenURL` probing and the deep-link handoff.
+    public let urlScheme: String
+
+    /// SF Symbol used when the host app has no bundled asset for this signer.
+    public let sfSymbolFallback: String
+
+    /// Optional bundled image asset name. Hosts that want branded icons can ship matching assets
+    /// (e.g. `"PrimalLogo"`) — the registry doesn't ship images itself.
+    public let iconAssetName: String?
+
+    /// Relay hints the signer prefers. Apps may pass these to ``NDKBunkerSigner/nostrConnect``
+    /// when the user explicitly chose this signer. Empty means no hint.
+    public let preferredRelays: [String]
+
+    public init(
+        id: String,
+        displayName: String,
+        urlScheme: String,
+        sfSymbolFallback: String = "key.fill",
+        iconAssetName: String? = nil,
+        preferredRelays: [String] = []
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.urlScheme = urlScheme
+        self.sfSymbolFallback = sfSymbolFallback
+        self.iconAssetName = iconAssetName
+        self.preferredRelays = preferredRelays
+    }
+}
+
+public extension NDKKnownSigner {
+    /// Amber (Android-only — included for completeness; iOS detection will always be false).
+    static let amber = NDKKnownSigner(
+        id: "amber",
+        displayName: "Amber",
+        urlScheme: "nostrsigner",
+        sfSymbolFallback: "key.fill"
+    )
+
+    /// Primal iOS signer. Reads `callback=` query parameter to return to the host app.
+    static let primal = NDKKnownSigner(
+        id: "primal",
+        displayName: "Primal",
+        urlScheme: "primal",
+        sfSymbolFallback: "bolt.fill",
+        preferredRelays: ["wss://relay.primal.net"]
+    )
+
+    /// nsec.app — web-based signer using `auth_url` challenges over NIP-46.
+    static let nsecApp = NDKKnownSigner(
+        id: "nsec.app",
+        displayName: "nsec.app",
+        urlScheme: "nostrconnect",
+        sfSymbolFallback: "globe"
+    )
+
+    /// Default seed list of known iOS-relevant signers.
+    ///
+    /// Seed data, not architecture: apps can supply their own array to ``NDKLocalSigner`` and the
+    /// connect model. Future versions may augment this with NIP-89 `kind:31990` discovery.
+    static let allKnown: [NDKKnownSigner] = [.amber, .primal, .nsecApp]
+}

--- a/Sources/NDKSwiftUI/Auth/NDKLocalSigner.swift
+++ b/Sources/NDKSwiftUI/Auth/NDKLocalSigner.swift
@@ -1,0 +1,79 @@
+import Foundation
+import OSLog
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Probes the device for installed NIP-46 signer apps using their custom URL schemes.
+///
+/// ## Required host setup
+///
+/// `UIApplication.canOpenURL` silently returns `false` for any scheme that is not declared in the
+/// host app's `Info.plist > LSApplicationQueriesSchemes`. If you intend to detect Amber, Primal,
+/// etc., add the relevant entries — otherwise detection will fail silently. ``detect(from:)`` will
+/// log a one-shot diagnostic when this footgun is the most likely cause.
+@MainActor
+public enum NDKLocalSigner {
+    private static let logger = Logger(subsystem: "NDKSwiftUI", category: "LocalSigner")
+    nonisolated(unsafe) private static var didWarnAboutMissingQueriesSchemes = false
+
+    /// Returns `true` if a signer app advertising `signer.urlScheme` is installed on the device.
+    ///
+    /// On platforms without UIKit (macOS, Linux) this always returns `false`.
+    public static func isInstalled(_ signer: NDKKnownSigner) -> Bool {
+        #if canImport(UIKit)
+        guard let url = URL(string: "\(signer.urlScheme)://") else { return false }
+        return UIApplication.shared.canOpenURL(url)
+        #else
+        return false
+        #endif
+    }
+
+    /// Returns the first signer from `registry` whose URL scheme `canOpenURL` accepts, or `nil`.
+    ///
+    /// Order is significant: pass the registry sorted by user preference (most-specific first).
+    /// If zero schemes resolve and there is reason to believe at least one signer should be
+    /// installed, emit a one-shot warning pointing at the most common cause: missing
+    /// `LSApplicationQueriesSchemes` entries in `Info.plist`.
+    public static func detect(from registry: [NDKKnownSigner] = NDKKnownSigner.allKnown) -> NDKKnownSigner? {
+        #if canImport(UIKit)
+        for signer in registry where isInstalled(signer) {
+            return signer
+        }
+        warnIfQueriesSchemesLikelyMissing(probed: registry)
+        return nil
+        #else
+        return nil
+        #endif
+    }
+
+    /// Returns every signer from `registry` whose URL scheme `canOpenURL` accepts. Useful when
+    /// presenting a chooser of all installed signers rather than auto-picking one.
+    public static func allInstalled(from registry: [NDKKnownSigner] = NDKKnownSigner.allKnown) -> [NDKKnownSigner] {
+        #if canImport(UIKit)
+        let installed = registry.filter(isInstalled)
+        if installed.isEmpty {
+            warnIfQueriesSchemesLikelyMissing(probed: registry)
+        }
+        return installed
+        #else
+        return []
+        #endif
+    }
+
+    private static func warnIfQueriesSchemesLikelyMissing(probed: [NDKKnownSigner]) {
+        guard !didWarnAboutMissingQueriesSchemes else { return }
+
+        let declared = Bundle.main.object(forInfoDictionaryKey: "LSApplicationQueriesSchemes") as? [String] ?? []
+        let missing = probed.map(\.urlScheme).filter { !declared.contains($0) }
+        guard !missing.isEmpty else { return }
+
+        didWarnAboutMissingQueriesSchemes = true
+        logger.warning("""
+            No NIP-46 signer detected via canOpenURL. Likely cause: these schemes are not in your \
+            Info.plist > LSApplicationQueriesSchemes — \(missing, privacy: .public). \
+            Without these entries, canOpenURL returns false even when the signer is installed.
+            """)
+    }
+}

--- a/Tests/NDKSwiftTests/Unit/Signers/NDKBunkerSignerTests.swift
+++ b/Tests/NDKSwiftTests/Unit/Signers/NDKBunkerSignerTests.swift
@@ -322,11 +322,14 @@ final class NDKBunkerSignerTests: XCTestCase {
         XCTAssertNotNil(uri)
 
         if let uri = uri {
-            // Should properly encode special characters
-            // The actual implementation may vary in how it encodes URLs
-            XCTAssertTrue(uri.contains("name=Test%20&%20App"), "Expected name parameter with encoded space")
-            XCTAssertTrue(uri.contains("url=https://test.com/path?query=1"), "Expected URL parameter")
-            XCTAssertTrue(uri.contains("relay=wss://relay.test.com/path"), "Expected relay parameter")
+            // Should properly encode special characters per RFC 3986: `&` in a query value must
+            // be percent-encoded as `%26`, otherwise it terminates the query item.
+            let components = URLComponents(string: uri)
+            let queryItems = components?.queryItems ?? []
+            XCTAssertEqual(queryItems.first(where: { $0.name == "name" })?.value, "Test & App")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "url" })?.value, "https://test.com/path?query=1")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "relay" })?.value, "wss://relay.test.com/path")
+            XCTAssertTrue(uri.contains("name=Test%20%26%20App"), "Expected `&` to be percent-encoded as %26 in: \(uri)")
         }
     }
 

--- a/Tests/NDKSwiftTests/Unit/Signers/NostrConnectURIBuilderTests.swift
+++ b/Tests/NDKSwiftTests/Unit/Signers/NostrConnectURIBuilderTests.swift
@@ -1,0 +1,121 @@
+@testable import NDKSwiftCore
+import XCTest
+
+@MainActor
+final class NostrConnectURIBuilderTests: XCTestCase {
+    private func makeNDK() async throws -> NDK {
+        return try await NDKTestFactory.createNDK()
+    }
+
+    // MARK: - extraQueryItems
+
+    func testExtraQueryItemsAppearInGeneratedURI() async throws {
+        let ndk = try await makeNDK()
+        let localSigner = try NDKPrivateKeySigner.generate()
+        let options = NDKBunkerSigner.NostrConnectOptions(
+            name: "MyApp",
+            extraQueryItems: [
+                URLQueryItem(name: "callback", value: "myapp://nip46"),
+                URLQueryItem(name: "vendor_flag", value: "1"),
+            ]
+        )
+
+        let signer = try await NDKBunkerSigner.nostrConnect(
+            ndk: ndk,
+            relays: ["wss://relay.example.com"],
+            localSigner: localSigner,
+            options: options
+        )
+
+        let maybeURI = await signer.nostrConnectUri
+        let uri = try XCTUnwrap(maybeURI)
+        let components = try XCTUnwrap(URLComponents(string: uri))
+        let items = components.queryItems ?? []
+
+        XCTAssertTrue(items.contains(URLQueryItem(name: "callback", value: "myapp://nip46")),
+                      "Expected callback query item in URI: \(uri)")
+        XCTAssertTrue(items.contains(URLQueryItem(name: "vendor_flag", value: "1")),
+                      "Expected vendor_flag query item in URI: \(uri)")
+    }
+
+    func testNilExtraQueryItemsBackwardCompatible() async throws {
+        let ndk = try await makeNDK()
+        let localSigner = try NDKPrivateKeySigner.generate()
+        let options = NDKBunkerSigner.NostrConnectOptions(name: "MyApp", url: "https://myapp.com")
+
+        let signer = try await NDKBunkerSigner.nostrConnect(
+            ndk: ndk,
+            relays: ["wss://relay.example.com"],
+            localSigner: localSigner,
+            options: options
+        )
+
+        let maybeURI = await signer.nostrConnectUri
+        let uri = try XCTUnwrap(maybeURI)
+        XCTAssertTrue(uri.hasPrefix("nostrconnect://"))
+        XCTAssertTrue(uri.contains("name=MyApp"))
+        XCTAssertTrue(uri.contains("url=https://myapp.com"))
+    }
+
+    // MARK: - URI structure
+
+    func testURISchemeAndHostAreCorrect() async throws {
+        let ndk = try await makeNDK()
+        let localSigner = try NDKPrivateKeySigner.generate()
+        let expectedPubkey = try await localSigner.pubkey
+
+        let signer = try await NDKBunkerSigner.nostrConnect(
+            ndk: ndk,
+            relays: ["wss://relay.example.com"],
+            localSigner: localSigner
+        )
+
+        let maybeURI = await signer.nostrConnectUri
+        let uri = try XCTUnwrap(maybeURI)
+        let components = try XCTUnwrap(URLComponents(string: uri))
+        XCTAssertEqual(components.scheme, "nostrconnect")
+        XCTAssertEqual(components.host, expectedPubkey)
+    }
+
+    func testMultipleRelaysProduceMultipleRelayQueryItems() async throws {
+        let ndk = try await makeNDK()
+        let localSigner = try NDKPrivateKeySigner.generate()
+        let relays = ["wss://relay1.example.com", "wss://relay2.example.com"]
+
+        let signer = try await NDKBunkerSigner.nostrConnect(
+            ndk: ndk,
+            relays: relays,
+            localSigner: localSigner
+        )
+
+        let maybeURI = await signer.nostrConnectUri
+        let uri = try XCTUnwrap(maybeURI)
+        let components = try XCTUnwrap(URLComponents(string: uri))
+        let relayValues = (components.queryItems ?? [])
+            .filter { $0.name == "relay" }
+            .compactMap(\.value)
+        XCTAssertEqual(Set(relayValues), Set(relays))
+    }
+
+    func testValuesWithSpacesArePercentEncoded() async throws {
+        let ndk = try await makeNDK()
+        let localSigner = try NDKPrivateKeySigner.generate()
+        let options = NDKBunkerSigner.NostrConnectOptions(name: "Hello World")
+
+        let signer = try await NDKBunkerSigner.nostrConnect(
+            ndk: ndk,
+            relays: ["wss://relay.example.com"],
+            localSigner: localSigner,
+            options: options
+        )
+
+        let maybeURI = await signer.nostrConnectUri
+        let uri = try XCTUnwrap(maybeURI)
+        XCTAssertTrue(uri.contains("name=Hello%20World"), "Expected percent-encoded space in: \(uri)")
+
+        // Re-parsed via URLComponents the value should round-trip as the original string.
+        let components = try XCTUnwrap(URLComponents(string: uri))
+        let nameValue = (components.queryItems ?? []).first(where: { $0.name == "name" })?.value
+        XCTAssertEqual(nameValue, "Hello World")
+    }
+}


### PR DESCRIPTION
## Summary

Lifts the "is Primal/Amber installed → tap to deep-link → return via callback" flow out of host apps (Olas hand-rolls ~250 lines of this) and into NDKSwift. Any NDKSwift-based iOS app gets the UX in ~5 lines of SwiftUI; the lower-level pieces are usable without the SwiftUI model.

## What's in

**`NDKSwiftCore`** (cross-platform, additive):
- `NostrConnectOptions.extraQueryItems`: escape hatch for vendor params (iOS `callback=`, per-signer flags). NIP-46 only standardizes `name/url/image/perms/secret/relay` — this is where non-standard extensions go without the library blessing one convention as protocol.
- `generateNostrConnectUri` rewritten on `URLComponents`. The old string-append did **not** encode `&` inside query values, producing technically broken URIs that some parsers accepted by accident.

**`NDKSwiftUI/Auth/`** (iOS):
- `NDKKnownSigner` — pure-data registry of known iOS signers (Amber, Primal, nsec.app). Seed statics + public init for customs. Future: NIP-89 `kind:31990` discovery for the QR/paste fallback.
- `NDKLocalSigner` — `canOpenURL` detection behind `canImport(UIKit)`, with a one-shot debug warning when `LSApplicationQueriesSchemes` is the likely cause of zero detections (hard-to-diagnose iOS sandbox footgun).
- `NDKBunkerConnectModel` — `@MainActor @Observable` orchestrator. State enum splits `awaitingAuthChallenge(URL)` from `waitingForApproval` (NIP-46 `auth_url` for nsec.app's web-OAuth flow needs its own state). Real timeout, `expectedPubkey` validation for reconnect, SwiftUI `handoff(using: OpenURLAction)`.

## Design decisions

**Why `@Observable` instead of returning the signer from a plain `async` function?** Both — the model wraps the async API, it doesn't replace it. The JS ecosystem (NDK, nostr-tools, applesauce, Nostrify) standardized on Promise + `onAuth` callback; `NDKBunkerSigner.nostrConnect` + `authUrlPublisher` is already the Swift equivalent. The model exists to bind that lifecycle to SwiftUI state for the common case.

**Why `callback` and not generic `return`/`returnUrl`?** Empirically `callback` is the de-facto convention: Primal-iOS reads it and calls `UIApplication.shared.open`; Nostrify writes it. Accepting aliases would create its own ambiguity. The library accepts a typed `callbackURL: URL?` and injects it via `extraQueryItems` — not blessed as protocol, but the convenience hook for the convention.

**Why is the registry in `NDKSwiftUI` not Core?** `sfSymbolFallback`, `iconAssetName`, and `canOpenURL` are UI/platform concepts. Putting them in Core would leak UIKit into the cross-platform module.

## Usage (any host app)

```swift
struct LoginView: View {
    let ndk: NDK
    @State private var connect: NDKBunkerConnectModel
    @Environment(\.openURL) private var openURL

    init(ndk: NDK) {
        self.ndk = ndk
        _connect = State(initialValue: NDKBunkerConnectModel(
            ndk: ndk,
            relays: ["wss://relay.primal.net"],
            options: .init(name: "MyApp", url: "https://myapp", perms: "sign_event:1,…"),
            callbackURL: URL(string: "myapp://nip46")
        ))
    }

    var body: some View {
        VStack {
            if let signer = connect.detectedSigner {
                Button("Open \(signer.displayName)") { connect.handoff(using: openURL) }
            }
            // … render QR from connect.nostrConnectURI as a fallback
        }
        .task { await connect.start() }
        .onChange(of: connect.state) { _, newState in
            if case .connected(let signer) = newState {
                // signer is ready
            }
        }
    }
}
```

Host prereqs (documented inline):
1. Register a custom URL scheme in `Info.plist > CFBundleURLTypes`.
2. List probed schemes in `LSApplicationQueriesSchemes` — without this, `canOpenURL` silently lies.

## Test plan

- [x] `swift test --filter NostrConnectURIBuilderTests` — 5 new tests pass (extraQueryItems injection, scheme/host correctness, multi-relay, percent-encoding round-trip, backward compat with `nil` extras)
- [x] `swift test --filter NDKBunkerSignerTests` — all 22 existing pass; `testNostrConnectURIWithSpecialCharacters` updated to assert the now-correct RFC 3986 encoding (`&` → `%26`)
- [x] `swift build --target NDKSwiftCore` clean
- [x] `swift build --target NDKSwiftUI` clean
- [ ] Manual smoke test in a host app — recommended before merge: drop `NDKBunkerConnectModel` into Olas's LoginView and verify Primal handoff still works end-to-end

## Deferred to follow-up PRs

- `BunkerPersistence` (Keychain) + `get_public_key()`-based reconnect validation. The `expectedPubkey` parameter is in place; the persistence layer that supplies it isn't.
- NIP-89 `kind:31990 + k=24133` bunker-provider discovery for the no-installed-signer fallback (mirrors `nostr-tools` `fetchBunkerProviders`).
- Typed `Permissions` struct replacing comma-string `perms`. This would break the public init signature, so it deserves its own PR + migration.
- Composable view parts: `NDKBunkerHeroButton`, `NDKBunkerQRView`, `NDKBunkerPasteField`. The current PR ships only the model; apps can compose the hero themselves.

## Build note

Local `swift build` of the full package fails on `Swift-BigInt 2.3.0` (transitive dep via CashuSwift) under Swift 6.3.2 because of an operator-ambiguity check tightened in recent compilers — pre-existing, unrelated. Per-target builds of `NDKSwiftCore` and `NDKSwiftUI` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)